### PR TITLE
User profile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ On a high level, the API is a CRUD application for `aiof` data. It is based on a
 Migrations are managed in the `ef-migrations` branch
 
 ```powershell
-dotnet ef migrations add {migration name}
-dotnet ef migrations script
-dotnet ef migrations script {migration name}
+dotnet ef migrations add {migration name} -p .\aiof.api.data
+dotnet ef migrations script -p .\aiof.api.data
+dotnet ef migrations script {migration name} -p .\aiof.api.data
 dotnet ef migrations remove
 ```
 

--- a/aiof.api.core/Controllers/UserController.cs
+++ b/aiof.api.core/Controllers/UserController.cs
@@ -267,5 +267,16 @@ namespace aiof.api.core.Controllers
         {
             return Ok(await _repo.GetHouseholdChildrenAsync());
         }
+
+        /// <summary>
+        /// Get User profile options
+        /// </summary>
+        [HttpGet]
+        [Route("profile/options")]
+        [ProducesResponseType(typeof(IUserProfileOptions), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetUserProfileOptionsAsync()
+        {
+            return Ok(await _repo.GetUserProfileOptionsAsync());
+        }
     }
 }

--- a/aiof.api.core/Controllers/UserController.cs
+++ b/aiof.api.core/Controllers/UserController.cs
@@ -234,5 +234,16 @@ namespace aiof.api.core.Controllers
         {
             return Ok(await _repo.GetMaritalStatusesAsync());
         }
+
+        /// <summary>
+        /// Get Residential statuses
+        /// </summary>
+        [HttpGet]
+        [Route("residential/statuses")]
+        [ProducesResponseType(typeof(IEnumerable<IResidentialStatus>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetResidentialStatusesAsync()
+        {
+            return Ok(await _repo.GetResidentialStatusesAsync());
+        }
     }
 }

--- a/aiof.api.core/Controllers/UserController.cs
+++ b/aiof.api.core/Controllers/UserController.cs
@@ -245,5 +245,16 @@ namespace aiof.api.core.Controllers
         {
             return Ok(await _repo.GetResidentialStatusesAsync());
         }
+
+        /// <summary>
+        /// Get Genders
+        /// </summary>
+        [HttpGet]
+        [Route("genders")]
+        [ProducesResponseType(typeof(IEnumerable<IGender>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetGendersAsync()
+        {
+            return Ok(await _repo.GetGendersAsync());
+        }
     }
 }

--- a/aiof.api.core/Controllers/UserController.cs
+++ b/aiof.api.core/Controllers/UserController.cs
@@ -256,5 +256,16 @@ namespace aiof.api.core.Controllers
         {
             return Ok(await _repo.GetHouseholdAdultsAsync());
         }
+
+        /// <summary>
+        /// Get Household children
+        /// </summary>
+        [HttpGet]
+        [Route("household/children")]
+        [ProducesResponseType(typeof(IEnumerable<IHouseholdChild>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetHouseholdChildrenAsync()
+        {
+            return Ok(await _repo.GetHouseholdChildrenAsync());
+        }
     }
 }

--- a/aiof.api.core/Controllers/UserController.cs
+++ b/aiof.api.core/Controllers/UserController.cs
@@ -247,14 +247,14 @@ namespace aiof.api.core.Controllers
         }
 
         /// <summary>
-        /// Get Genders
+        /// Get Household adults
         /// </summary>
         [HttpGet]
-        [Route("genders")]
-        [ProducesResponseType(typeof(IEnumerable<IGender>), StatusCodes.Status200OK)]
-        public async Task<IActionResult> GetGendersAsync()
+        [Route("household/adults")]
+        [ProducesResponseType(typeof(IEnumerable<IHouseholdAdult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetHouseholdAdultsAsync()
         {
-            return Ok(await _repo.GetGendersAsync());
+            return Ok(await _repo.GetHouseholdAdultsAsync());
         }
     }
 }

--- a/aiof.api.core/Controllers/UserController.cs
+++ b/aiof.api.core/Controllers/UserController.cs
@@ -223,5 +223,16 @@ namespace aiof.api.core.Controllers
         {
             return Ok(await _repo.GetEducationLevelsAsync());
         }
+
+        /// <summary>
+        /// Get Marital statuses
+        /// </summary>
+        [HttpGet]
+        [Route("marital/statuses")]
+        [ProducesResponseType(typeof(IEnumerable<IMaritalStatus>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetMaritalStatusesAsync()
+        {
+            return Ok(await _repo.GetMaritalStatusesAsync());
+        }
     }
 }

--- a/aiof.api.data/AiofContext.cs
+++ b/aiof.api.data/AiofContext.cs
@@ -26,6 +26,7 @@ namespace aiof.api.data
         public virtual DbSet<AccountTypeMap> AccountTypeMaps { get; set; }
         public virtual DbSet<EducationLevel> EducationLevels { get; set; }
         public virtual DbSet<MaritalStatus> MaritalStatuses { get; set; }
+        public virtual DbSet<ResidentialStatus> ResidentialStatuses { get; set; }
 
         public AiofContext(DbContextOptions<AiofContext> options, ITenant tenant)
             : base(options)
@@ -312,6 +313,16 @@ namespace aiof.api.data
             modelBuilder.Entity<MaritalStatus>(e =>
             {
                 e.ToTable(Keys.Entity.MaritalStatus);
+
+                e.HasKey(x => x.Name);
+
+                e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+            });
+
+            modelBuilder.Entity<ResidentialStatus>(e =>
+            {
+                e.ToTable(Keys.Entity.ResidentialStatus);
 
                 e.HasKey(x => x.Name);
 

--- a/aiof.api.data/AiofContext.cs
+++ b/aiof.api.data/AiofContext.cs
@@ -27,6 +27,7 @@ namespace aiof.api.data
         public virtual DbSet<EducationLevel> EducationLevels { get; set; }
         public virtual DbSet<MaritalStatus> MaritalStatuses { get; set; }
         public virtual DbSet<ResidentialStatus> ResidentialStatuses { get; set; }
+        public virtual DbSet<Gender> Genders { get; set; }
 
         public AiofContext(DbContextOptions<AiofContext> options, ITenant tenant)
             : base(options)
@@ -323,6 +324,16 @@ namespace aiof.api.data
             modelBuilder.Entity<ResidentialStatus>(e =>
             {
                 e.ToTable(Keys.Entity.ResidentialStatus);
+
+                e.HasKey(x => x.Name);
+
+                e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+            });
+
+            modelBuilder.Entity<Gender>(e =>
+            {
+                e.ToTable(Keys.Entity.Gender);
 
                 e.HasKey(x => x.Name);
 

--- a/aiof.api.data/AiofContext.cs
+++ b/aiof.api.data/AiofContext.cs
@@ -25,6 +25,7 @@ namespace aiof.api.data
         public virtual DbSet<AccountType> AccountTypes { get; set; }
         public virtual DbSet<AccountTypeMap> AccountTypeMaps { get; set; }
         public virtual DbSet<EducationLevel> EducationLevels { get; set; }
+        public virtual DbSet<MaritalStatus> MaritalStatuses { get; set; }
 
         public AiofContext(DbContextOptions<AiofContext> options, ITenant tenant)
             : base(options)
@@ -301,6 +302,16 @@ namespace aiof.api.data
             modelBuilder.Entity<EducationLevel>(e =>
             {
                 e.ToTable(Keys.Entity.EducationLevel);
+
+                e.HasKey(x => x.Name);
+
+                e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+            });
+
+            modelBuilder.Entity<MaritalStatus>(e =>
+            {
+                e.ToTable(Keys.Entity.MaritalStatus);
 
                 e.HasKey(x => x.Name);
 

--- a/aiof.api.data/AiofContext.cs
+++ b/aiof.api.data/AiofContext.cs
@@ -28,6 +28,7 @@ namespace aiof.api.data
         public virtual DbSet<MaritalStatus> MaritalStatuses { get; set; }
         public virtual DbSet<ResidentialStatus> ResidentialStatuses { get; set; }
         public virtual DbSet<Gender> Genders { get; set; }
+        public virtual DbSet<HouseholdAdult> HouseholdAdults { get; set; }
 
         public AiofContext(DbContextOptions<AiofContext> options, ITenant tenant)
             : base(options)
@@ -334,6 +335,16 @@ namespace aiof.api.data
             modelBuilder.Entity<Gender>(e =>
             {
                 e.ToTable(Keys.Entity.Gender);
+
+                e.HasKey(x => x.Name);
+
+                e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+            });
+
+            modelBuilder.Entity<HouseholdAdult>(e =>
+            {
+                e.ToTable(Keys.Entity.HouseholdAdult);
 
                 e.HasKey(x => x.Name);
 

--- a/aiof.api.data/AiofContext.cs
+++ b/aiof.api.data/AiofContext.cs
@@ -29,6 +29,7 @@ namespace aiof.api.data
         public virtual DbSet<ResidentialStatus> ResidentialStatuses { get; set; }
         public virtual DbSet<Gender> Genders { get; set; }
         public virtual DbSet<HouseholdAdult> HouseholdAdults { get; set; }
+        public virtual DbSet<HouseholdChild> HouseholdChildren { get; set; }
 
         public AiofContext(DbContextOptions<AiofContext> options, ITenant tenant)
             : base(options)
@@ -345,6 +346,16 @@ namespace aiof.api.data
             modelBuilder.Entity<HouseholdAdult>(e =>
             {
                 e.ToTable(Keys.Entity.HouseholdAdult);
+
+                e.HasKey(x => x.Name);
+
+                e.Property(x => x.Name).HasSnakeCaseColumnName().HasMaxLength(100).IsRequired();
+                e.Property(x => x.PublicKey).HasSnakeCaseColumnName().IsRequired();
+            });
+
+            modelBuilder.Entity<HouseholdChild>(e =>
+            {
+                e.ToTable(Keys.Entity.HouseholdChild);
 
                 e.HasKey(x => x.Name);
 

--- a/aiof.api.data/FakeDataManager.cs
+++ b/aiof.api.data/FakeDataManager.cs
@@ -70,6 +70,9 @@ namespace aiof.api.data
             _context.HouseholdAdults
                 .AddRange(GetFakeHouseholdAdults());
 
+            _context.HouseholdChildren
+                .AddRange(GetFakeHouseholdChildren());
+
             _context.SaveChanges();
         }
 
@@ -659,6 +662,45 @@ namespace aiof.api.data
                 new HouseholdAdult
                 {
                     Name = "6+ adults"
+                }
+            };
+        }
+
+        public IEnumerable<HouseholdChild> GetFakeHouseholdChildren()
+        {
+            return new List<HouseholdChild>
+            {
+                new HouseholdChild
+                {
+                    Name = "0 children"
+                },
+                new HouseholdChild
+                {
+                    Name = "1 child"
+                },
+                new HouseholdChild
+                {
+                    Name = "2 children"
+                },
+                new HouseholdChild
+                {
+                    Name = "3 children"
+                },
+                new HouseholdChild
+                {
+                    Name = "4 children"
+                },
+                new HouseholdChild
+                {
+                    Name = "5 children"
+                },
+                new HouseholdChild
+                {
+                    Name = "6 children"
+                },
+                new HouseholdChild
+                {
+                    Name = "6+ children"
                 }
             };
         }

--- a/aiof.api.data/FakeDataManager.cs
+++ b/aiof.api.data/FakeDataManager.cs
@@ -58,6 +58,9 @@ namespace aiof.api.data
             _context.EducationLevels
                 .AddRange(GetFakeEducationLevels());
 
+            _context.MaritalStatuses
+                .AddRange(GetFakeMaritalStatuses());
+
             _context.SaveChanges();
         }
 
@@ -535,6 +538,29 @@ namespace aiof.api.data
                 new EducationLevel
                 {
                     Name = "Doctorate"
+                }
+            };
+        }
+
+        public IEnumerable<MaritalStatus> GetFakeMaritalStatuses()
+        {
+            return new List<MaritalStatus>
+            {
+                new MaritalStatus
+                {
+                    Name = "Single"
+                },
+                new MaritalStatus
+                {
+                    Name = "Married"
+                },
+                new MaritalStatus
+                {
+                    Name = "Living together"
+                },
+                new MaritalStatus
+                {
+                    Name = "No longer married"
                 }
             };
         }

--- a/aiof.api.data/FakeDataManager.cs
+++ b/aiof.api.data/FakeDataManager.cs
@@ -67,6 +67,9 @@ namespace aiof.api.data
             _context.Genders
                 .AddRange(GetFakeGenders());
 
+            _context.HouseholdAdults
+                .AddRange(GetFakeHouseholdAdults());
+
             _context.SaveChanges();
         }
 
@@ -621,6 +624,41 @@ namespace aiof.api.data
                 new Gender
                 {
                     Name = "Other"
+                }
+            };
+        }
+
+        public IEnumerable<HouseholdAdult> GetFakeHouseholdAdults()
+        {
+            return new List<HouseholdAdult>
+            {
+                new HouseholdAdult
+                {
+                    Name = "1 adult"
+                },
+                new HouseholdAdult
+                {
+                    Name = "2 adults"
+                },
+                new HouseholdAdult
+                {
+                    Name = "3 adults"
+                },
+                new HouseholdAdult
+                {
+                    Name = "4 adults"
+                },
+                new HouseholdAdult
+                {
+                    Name = "5 adults"
+                },
+                new HouseholdAdult
+                {
+                    Name = "6 adults"
+                },
+                new HouseholdAdult
+                {
+                    Name = "6+ adults"
                 }
             };
         }

--- a/aiof.api.data/FakeDataManager.cs
+++ b/aiof.api.data/FakeDataManager.cs
@@ -61,6 +61,9 @@ namespace aiof.api.data
             _context.MaritalStatuses
                 .AddRange(GetFakeMaritalStatuses());
 
+            _context.ResidentialStatuses
+                .AddRange(GetFakeResidentialStatuses());
+
             _context.SaveChanges();
         }
 
@@ -561,6 +564,41 @@ namespace aiof.api.data
                 new MaritalStatus
                 {
                     Name = "No longer married"
+                }
+            };
+        }
+
+        public IEnumerable<ResidentialStatus> GetFakeResidentialStatuses()
+        {
+            return new List<ResidentialStatus>
+            {
+                new ResidentialStatus
+                {
+                    Name = "Living with parents / relatives"
+                },
+                new ResidentialStatus
+                {
+                    Name = "Couch surfing"
+                },
+                new ResidentialStatus
+                {
+                    Name = "Renting with friends"
+                },
+                new ResidentialStatus
+                {
+                    Name = "Renting by myself"
+                },
+                new ResidentialStatus
+                {
+                    Name = "Campus housing"
+                },
+                new ResidentialStatus
+                {
+                    Name = "I own a condo"
+                },
+                new ResidentialStatus
+                {
+                    Name = "I own a house"
                 }
             };
         }

--- a/aiof.api.data/FakeDataManager.cs
+++ b/aiof.api.data/FakeDataManager.cs
@@ -64,6 +64,9 @@ namespace aiof.api.data
             _context.ResidentialStatuses
                 .AddRange(GetFakeResidentialStatuses());
 
+            _context.Genders
+                .AddRange(GetFakeGenders());
+
             _context.SaveChanges();
         }
 
@@ -599,6 +602,25 @@ namespace aiof.api.data
                 new ResidentialStatus
                 {
                     Name = "I own a house"
+                }
+            };
+        }
+
+        public IEnumerable<Gender> GetFakeGenders()
+        {
+            return new List<Gender>
+            {
+                new Gender
+                {
+                    Name = "Male"
+                },
+                new Gender
+                {
+                    Name = "Female"
+                },
+                new Gender
+                {
+                    Name = "Other"
                 }
             };
         }

--- a/aiof.api.data/Gender.cs
+++ b/aiof.api.data/Gender.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public class Gender : IGender,
+        IPublicKeyName
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+    }
+}

--- a/aiof.api.data/HouseholdAdult.cs
+++ b/aiof.api.data/HouseholdAdult.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public class HouseholdAdult : IHouseholdAdult,
+        IPublicKeyName
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+    }
+}

--- a/aiof.api.data/HouseholdChild.cs
+++ b/aiof.api.data/HouseholdChild.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public class HouseholdChild : IHouseholdChild,
+        IPublicKeyName
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+    }
+}

--- a/aiof.api.data/IGender.cs
+++ b/aiof.api.data/IGender.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public interface IGender
+    {
+        [Required]
+        [MaxLength(100)]
+        string Name { get; set; }
+
+        [Required]
+        Guid PublicKey { get; set; }
+    }
+}

--- a/aiof.api.data/IHouseholdAdult.cs
+++ b/aiof.api.data/IHouseholdAdult.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public interface IHouseholdAdult
+    {
+        [Required]
+        [MaxLength(100)]
+        string Name { get; set; }
+
+        [Required]
+        Guid PublicKey { get; set; }
+    }
+}

--- a/aiof.api.data/IHouseholdChild.cs
+++ b/aiof.api.data/IHouseholdChild.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public interface IHouseholdChild
+    {
+        [Required]
+        [MaxLength(100)]
+        string Name { get; set; }
+
+        [Required]
+        Guid PublicKey { get; set; }
+    }
+}

--- a/aiof.api.data/IMaritalStatus.cs
+++ b/aiof.api.data/IMaritalStatus.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public interface IMaritalStatus
+    {
+        [Required]
+        [MaxLength(100)]
+        string Name { get; set; }
+
+        [Required]
+        Guid PublicKey { get; set; }
+    }
+}

--- a/aiof.api.data/IResidentialStatus.cs
+++ b/aiof.api.data/IResidentialStatus.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public interface IResidentialStatus
+    {
+        [Required]
+        [MaxLength(100)]
+        string Name { get; set; }
+
+        [Required]
+        Guid PublicKey { get; set; }
+    }
+}

--- a/aiof.api.data/IUserProfileOptions.cs
+++ b/aiof.api.data/IUserProfileOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace aiof.api.data
+{
+    public interface IUserProfileOptions
+    {
+        IEnumerable<IEducationLevel> EducationLevels { get; set; }
+        IEnumerable<IGender> Genders { get; set; }
+        IEnumerable<IHouseholdAdult> HouseholdAdults { get; set; }
+        IEnumerable<IHouseholdChild> HouseholdChildren { get; set; }
+        IEnumerable<IMaritalStatus> MaritalStatuses { get; set; }
+        IEnumerable<IResidentialStatus> ResidentialStatuses { get; set; }
+    }
+}

--- a/aiof.api.data/Keys.cs
+++ b/aiof.api.data/Keys.cs
@@ -81,6 +81,7 @@ namespace aiof.api.data
             public static string AccountType = nameof(data.AccountType).ToSnakeCase();
             public static string AccountTypeMap = nameof(data.AccountTypeMap).ToSnakeCase();
             public static string EducationLevel = nameof(data.EducationLevel).ToSnakeCase();
+            public static string MaritalStatus = nameof(data.MaritalStatus).ToSnakeCase();
         }
     }
 }

--- a/aiof.api.data/Keys.cs
+++ b/aiof.api.data/Keys.cs
@@ -83,6 +83,7 @@ namespace aiof.api.data
             public static string EducationLevel = nameof(data.EducationLevel).ToSnakeCase();
             public static string MaritalStatus = nameof(data.MaritalStatus).ToSnakeCase();
             public static string ResidentialStatus = nameof(data.ResidentialStatus).ToSnakeCase();
+            public static string Gender = nameof(data.Gender).ToSnakeCase();
         }
     }
 }

--- a/aiof.api.data/Keys.cs
+++ b/aiof.api.data/Keys.cs
@@ -82,6 +82,7 @@ namespace aiof.api.data
             public static string AccountTypeMap = nameof(data.AccountTypeMap).ToSnakeCase();
             public static string EducationLevel = nameof(data.EducationLevel).ToSnakeCase();
             public static string MaritalStatus = nameof(data.MaritalStatus).ToSnakeCase();
+            public static string ResidentialStatus = nameof(data.ResidentialStatus).ToSnakeCase();
         }
     }
 }

--- a/aiof.api.data/Keys.cs
+++ b/aiof.api.data/Keys.cs
@@ -85,6 +85,7 @@ namespace aiof.api.data
             public static string ResidentialStatus = nameof(data.ResidentialStatus).ToSnakeCase();
             public static string Gender = nameof(data.Gender).ToSnakeCase();
             public static string HouseholdAdult = nameof(data.HouseholdAdult).ToSnakeCase();
+            public static string HouseholdChild = nameof(data.HouseholdChild).ToSnakeCase();
         }
     }
 }

--- a/aiof.api.data/Keys.cs
+++ b/aiof.api.data/Keys.cs
@@ -84,6 +84,7 @@ namespace aiof.api.data
             public static string MaritalStatus = nameof(data.MaritalStatus).ToSnakeCase();
             public static string ResidentialStatus = nameof(data.ResidentialStatus).ToSnakeCase();
             public static string Gender = nameof(data.Gender).ToSnakeCase();
+            public static string HouseholdAdult = nameof(data.HouseholdAdult).ToSnakeCase();
         }
     }
 }

--- a/aiof.api.data/MaritalStatus.cs
+++ b/aiof.api.data/MaritalStatus.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public class MaritalStatus : IMaritalStatus,
+        IPublicKeyName
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+
+        [Required]
+        public Guid PublicKey { get; set; }
+    }
+}

--- a/aiof.api.data/MaritalStatus.cs
+++ b/aiof.api.data/MaritalStatus.cs
@@ -15,6 +15,6 @@ namespace aiof.api.data
         public string Name { get; set; }
 
         [Required]
-        public Guid PublicKey { get; set; }
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
     }
 }

--- a/aiof.api.data/ResidentialStatus.cs
+++ b/aiof.api.data/ResidentialStatus.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
+
+namespace aiof.api.data
+{
+    public class ResidentialStatus : IResidentialStatus,
+        IPublicKeyName
+    {
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+
+        [Required]
+        public Guid PublicKey { get; set; } = Guid.NewGuid();
+    }
+}

--- a/aiof.api.data/UserProfileOptions.cs
+++ b/aiof.api.data/UserProfileOptions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace aiof.api.data
+{
+    public class UserProfileOptions : IUserProfileOptions
+    {
+        public IEnumerable<IEducationLevel> EducationLevels { get; set; }
+        public IEnumerable<IMaritalStatus> MaritalStatuses { get; set; }
+        public IEnumerable<IResidentialStatus> ResidentialStatuses { get; set; }
+        public IEnumerable<IGender> Genders { get; set; }
+        public IEnumerable<IHouseholdAdult> HouseholdAdults { get; set; }
+        public IEnumerable<IHouseholdChild> HouseholdChildren { get; set; }
+    }
+}

--- a/aiof.api.services/IUserRepository.cs
+++ b/aiof.api.services/IUserRepository.cs
@@ -41,5 +41,6 @@ namespace aiof.api.services
         Task<IEnumerable<IMaritalStatus>> GetMaritalStatusesAsync();
         Task<IEnumerable<IResidentialStatus>> GetResidentialStatusesAsync();
         Task<IEnumerable<IGender>> GetGendersAsync();
+        Task<IEnumerable<IHouseholdAdult>> GetHouseholdAdultsAsync();
     }
 }

--- a/aiof.api.services/IUserRepository.cs
+++ b/aiof.api.services/IUserRepository.cs
@@ -39,5 +39,6 @@ namespace aiof.api.services
         Task DeleteAccountAsync(int id);
         Task<IEnumerable<IEducationLevel>> GetEducationLevelsAsync();
         Task<IEnumerable<IMaritalStatus>> GetMaritalStatusesAsync();
+        Task<IEnumerable<IResidentialStatus>> GetResidentialStatusesAsync();
     }
 }

--- a/aiof.api.services/IUserRepository.cs
+++ b/aiof.api.services/IUserRepository.cs
@@ -42,5 +42,6 @@ namespace aiof.api.services
         Task<IEnumerable<IResidentialStatus>> GetResidentialStatusesAsync();
         Task<IEnumerable<IGender>> GetGendersAsync();
         Task<IEnumerable<IHouseholdAdult>> GetHouseholdAdultsAsync();
+        Task<IEnumerable<IHouseholdChild>> GetHouseholdChildrenAsync();
     }
 }

--- a/aiof.api.services/IUserRepository.cs
+++ b/aiof.api.services/IUserRepository.cs
@@ -38,5 +38,6 @@ namespace aiof.api.services
             AccountDto accountDto);
         Task DeleteAccountAsync(int id);
         Task<IEnumerable<IEducationLevel>> GetEducationLevelsAsync();
+        Task<IEnumerable<IMaritalStatus>> GetMaritalStatusesAsync();
     }
 }

--- a/aiof.api.services/IUserRepository.cs
+++ b/aiof.api.services/IUserRepository.cs
@@ -40,5 +40,6 @@ namespace aiof.api.services
         Task<IEnumerable<IEducationLevel>> GetEducationLevelsAsync();
         Task<IEnumerable<IMaritalStatus>> GetMaritalStatusesAsync();
         Task<IEnumerable<IResidentialStatus>> GetResidentialStatusesAsync();
+        Task<IEnumerable<IGender>> GetGendersAsync();
     }
 }

--- a/aiof.api.services/IUserRepository.cs
+++ b/aiof.api.services/IUserRepository.cs
@@ -43,5 +43,6 @@ namespace aiof.api.services
         Task<IEnumerable<IGender>> GetGendersAsync();
         Task<IEnumerable<IHouseholdAdult>> GetHouseholdAdultsAsync();
         Task<IEnumerable<IHouseholdChild>> GetHouseholdChildrenAsync();
+        Task<IUserProfileOptions> GetUserProfileOptionsAsync();
     }
 }

--- a/aiof.api.services/UserRepository.cs
+++ b/aiof.api.services/UserRepository.cs
@@ -378,6 +378,13 @@ namespace aiof.api.services
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<IHouseholdAdult>> GetHouseholdAdultsAsync()
+        {
+            return await _context.HouseholdAdults
+                .AsNoTracking()
+                .ToListAsync();
+        }
         #endregion
     }
 }

--- a/aiof.api.services/UserRepository.cs
+++ b/aiof.api.services/UserRepository.cs
@@ -364,6 +364,13 @@ namespace aiof.api.services
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<IResidentialStatus>> GetResidentialStatusesAsync()
+        {
+            return await _context.ResidentialStatuses
+                .AsNoTracking()
+                .ToListAsync();
+        }
         #endregion
     }
 }

--- a/aiof.api.services/UserRepository.cs
+++ b/aiof.api.services/UserRepository.cs
@@ -357,6 +357,13 @@ namespace aiof.api.services
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<IMaritalStatus>> GetMaritalStatusesAsync()
+        {
+            return await _context.MaritalStatuses
+                .AsNoTracking()
+                .ToListAsync();
+        }
         #endregion
     }
 }

--- a/aiof.api.services/UserRepository.cs
+++ b/aiof.api.services/UserRepository.cs
@@ -371,6 +371,13 @@ namespace aiof.api.services
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<IGender>> GetGendersAsync()
+        {
+            return await _context.Genders
+                .AsNoTracking()
+                .ToListAsync();
+        }
         #endregion
     }
 }

--- a/aiof.api.services/UserRepository.cs
+++ b/aiof.api.services/UserRepository.cs
@@ -392,6 +392,19 @@ namespace aiof.api.services
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IUserProfileOptions> GetUserProfileOptionsAsync()
+        {
+            return new UserProfileOptions
+            {
+                EducationLevels = await GetEducationLevelsAsync(),
+                MaritalStatuses = await GetMaritalStatusesAsync(),
+                ResidentialStatuses = await GetResidentialStatusesAsync(),
+                Genders = await GetGendersAsync(),
+                HouseholdAdults = await GetHouseholdAdultsAsync(),
+                HouseholdChildren = await GetHouseholdChildrenAsync()
+            };
+        }
         #endregion
     }
 }

--- a/aiof.api.services/UserRepository.cs
+++ b/aiof.api.services/UserRepository.cs
@@ -385,6 +385,13 @@ namespace aiof.api.services
                 .AsNoTracking()
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<IHouseholdChild>> GetHouseholdChildrenAsync()
+        {
+            return await _context.HouseholdChildren
+                .AsNoTracking()
+                .ToListAsync();
+        }
         #endregion
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -384,5 +384,20 @@ namespace aiof.api.tests
             Assert.NotNull(gender.Name);
             Assert.NotEqual(Guid.Empty, gender.PublicKey);
         }
+
+        [Fact]
+        public async Task GetHouseholdAdultsAsync_IsSuccessful()
+        {
+            var _repo = new ServiceHelper().GetRequiredService<IUserRepository>();
+
+            var hhAdults = await _repo.GetHouseholdAdultsAsync();
+            var hhAdult = hhAdults.FirstOrDefault();
+
+            Assert.NotNull(hhAdults);
+            Assert.NotEmpty(hhAdults);
+            Assert.NotNull(hhAdult);
+            Assert.NotNull(hhAdult.Name);
+            Assert.NotEqual(Guid.Empty, hhAdult.PublicKey);
+        }
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -434,6 +434,20 @@ namespace aiof.api.tests
             Assert.NotEmpty(userProfileOptions.Genders);
             Assert.NotEmpty(userProfileOptions.HouseholdAdults);
             Assert.NotEmpty(userProfileOptions.HouseholdChildren);
+
+            AssertIPublicKeyName(userProfileOptions.EducationLevels.FirstOrDefault() as IPublicKeyName);
+            AssertIPublicKeyName(userProfileOptions.MaritalStatuses.FirstOrDefault() as IPublicKeyName);
+            AssertIPublicKeyName(userProfileOptions.ResidentialStatuses.FirstOrDefault() as IPublicKeyName);
+            AssertIPublicKeyName(userProfileOptions.Genders.FirstOrDefault() as IPublicKeyName);
+            AssertIPublicKeyName(userProfileOptions.HouseholdAdults.FirstOrDefault() as IPublicKeyName);
+            AssertIPublicKeyName(userProfileOptions.HouseholdChildren.FirstOrDefault() as IPublicKeyName);
+        }
+
+        private void AssertIPublicKeyName(IPublicKeyName obj)
+        {
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.Name);
+            Assert.NotEqual(Guid.Empty, obj.PublicKey);
         }
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -339,5 +339,20 @@ namespace aiof.api.tests
             Assert.NotNull(educationLevel.Name);
             Assert.NotEqual(Guid.Empty, educationLevel.PublicKey);
         }
+
+        [Fact]
+        public async Task GetMaritalStatusesAsync_IsSuccessful()
+        {
+            var _repo = new ServiceHelper().GetRequiredService<IUserRepository>();
+
+            var maritalStatuses = await _repo.GetMaritalStatusesAsync();
+            var maritalStatus = maritalStatuses.FirstOrDefault();
+
+            Assert.NotNull(maritalStatuses);
+            Assert.NotEmpty(maritalStatuses);
+            Assert.NotNull(maritalStatus);
+            Assert.NotNull(maritalStatus.Name);
+            Assert.NotEqual(Guid.Empty, maritalStatus.PublicKey);
+        }
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -354,5 +354,20 @@ namespace aiof.api.tests
             Assert.NotNull(maritalStatus.Name);
             Assert.NotEqual(Guid.Empty, maritalStatus.PublicKey);
         }
+
+        [Fact]
+        public async Task GetResidentialStatusesAsync_IsSuccessful()
+        {
+            var _repo = new ServiceHelper().GetRequiredService<IUserRepository>();
+
+            var residentialStatuses = await _repo.GetResidentialStatusesAsync();
+            var residentialStatus = residentialStatuses.FirstOrDefault();
+
+            Assert.NotNull(residentialStatuses);
+            Assert.NotEmpty(residentialStatuses);
+            Assert.NotNull(residentialStatus);
+            Assert.NotNull(residentialStatus.Name);
+            Assert.NotEqual(Guid.Empty, residentialStatus.PublicKey);
+        }
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -414,5 +414,26 @@ namespace aiof.api.tests
             Assert.NotNull(hhChild.Name);
             Assert.NotEqual(Guid.Empty, hhChild.PublicKey);
         }
+
+        [Fact]
+        public async Task GetUserProfileOptionsAsync_IsSuccessful()
+        {
+            var _repo = new ServiceHelper().GetRequiredService<IUserRepository>();
+
+            var userProfileOptions = await _repo.GetUserProfileOptionsAsync();
+
+            Assert.NotNull(userProfileOptions.EducationLevels);
+            Assert.NotNull(userProfileOptions.MaritalStatuses);
+            Assert.NotNull(userProfileOptions.ResidentialStatuses);
+            Assert.NotNull(userProfileOptions.Genders);
+            Assert.NotNull(userProfileOptions.HouseholdAdults);
+            Assert.NotNull(userProfileOptions.HouseholdChildren);
+            Assert.NotEmpty(userProfileOptions.EducationLevels);
+            Assert.NotEmpty(userProfileOptions.MaritalStatuses);
+            Assert.NotEmpty(userProfileOptions.ResidentialStatuses);
+            Assert.NotEmpty(userProfileOptions.Genders);
+            Assert.NotEmpty(userProfileOptions.HouseholdAdults);
+            Assert.NotEmpty(userProfileOptions.HouseholdChildren);
+        }
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -399,5 +399,20 @@ namespace aiof.api.tests
             Assert.NotNull(hhAdult.Name);
             Assert.NotEqual(Guid.Empty, hhAdult.PublicKey);
         }
+
+        [Fact]
+        public async Task GetHouseholdChildrenAsync_IsSuccessful()
+        {
+            var _repo = new ServiceHelper().GetRequiredService<IUserRepository>();
+
+            var hhChildren = await _repo.GetHouseholdChildrenAsync();
+            var hhChild = hhChildren.FirstOrDefault();
+
+            Assert.NotNull(hhChildren);
+            Assert.NotEmpty(hhChildren);
+            Assert.NotNull(hhChild);
+            Assert.NotNull(hhChild.Name);
+            Assert.NotEqual(Guid.Empty, hhChild.PublicKey);
+        }
     }
 }

--- a/aiof.api.tests/UserRepository.Tests.cs
+++ b/aiof.api.tests/UserRepository.Tests.cs
@@ -369,5 +369,20 @@ namespace aiof.api.tests
             Assert.NotNull(residentialStatus.Name);
             Assert.NotEqual(Guid.Empty, residentialStatus.PublicKey);
         }
+
+        [Fact]
+        public async Task GetGendersAsync_IsSuccessful()
+        {
+            var _repo = new ServiceHelper().GetRequiredService<IUserRepository>();
+
+            var genders = await _repo.GetGendersAsync();
+            var gender = genders.FirstOrDefault();
+
+            Assert.NotNull(genders);
+            Assert.NotEmpty(genders);
+            Assert.NotNull(gender);
+            Assert.NotNull(gender.Name);
+            Assert.NotEqual(Guid.Empty, gender.PublicKey);
+        }
     }
 }


### PR DESCRIPTION
Added user profile options. Created endpoint to get all user profile settings options such as education levels, marital status, etc.
- endpoint: `/user/profile/options`
- includes `EducationLevel`
- includes `MaritalStatus`
- includes `Gender`
- includes `ResidentialStatus`
- includes `HouseholdAdults`
- includes `HouseholdChildren`
- added entities for `MaritalStatus`, `Gender`, `ResidentialStatus`, `HouseholdAdults` and `HouseholdChildren`
- added fake data
- added unit tests